### PR TITLE
error 404 errors with rspec matcher

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -9,4 +9,12 @@ class ApiController < ApplicationController
 
     attrs
   end
+
+  def error_not_found(message='not found')
+    render status: 404, json: {
+             code: '404',
+             error: 'not_found',
+             message: message
+           }
+  end
 end

--- a/app/controllers/image_sets_controller.rb
+++ b/app/controllers/image_sets_controller.rb
@@ -1,26 +1,33 @@
 class ImageSetsController < ApiController
+  before_filter :require_image_set, except: [:create]
+
   def create
     @image_set = ImageSet.create(expanded_params)
-    render json: ImageSetSerializer.new(@image_set)
+
+    render_image_set
   end
 
   def update
-    @image_set = ImageSet.find(params[:id])
-    # TODO ERROR NOT FOUND UNLESS @image_set
-
     @image_set.update(expanded_params)
     @image_set.save
 
-    render json: ImageSetSerializer.new(@image_set)
+    render_image_set
   end
 
   def show
-    @image_set = ImageSet.find(params[:id])
-    # TODO ERROR NOT FOUND UNLESS @image_set
-    render json: ImageSetSerializer.new(@image_set)
+    render_image_set
   end
 
   private
+
+  def require_image_set
+    @image_set = ImageSet.find_by_id(params[:id])
+    return error_not_found('image set not found') unless @image_set
+  end
+
+  def render_image_set
+    render json: ImageSetSerializer.new(@image_set)
+  end
 
   def expanded_params
     @uploading_user = User.find_by_id(image_set_params[:user_id])

--- a/spec/controllers/image_sets_controller_spec.rb
+++ b/spec/controllers/image_sets_controller_spec.rb
@@ -7,6 +7,12 @@ RSpec.describe ImageSetsController, :type => :controller do
     before { request.call }
     subject { response }
     it { expect(subject).to serialize_to(ImageSetSerializer, image_set) }
+
+    describe 'not found' do
+      let(:request) { ->{ get :show, id: 'bad id' } }
+      before { request.call }
+      it { expect(subject).to error_not_found_with('image set not found') }
+    end
   end
 
   describe '#create' do

--- a/spec/support/errors.rb
+++ b/spec/support/errors.rb
@@ -1,0 +1,18 @@
+require 'rspec/expectations'
+
+RSpec::Matchers.define :error_not_found do
+  match do |actual|
+    response.code === '404'
+  end
+end
+
+RSpec::Matchers.define :error_not_found_with do |expected_message|
+  match do |actual|
+    response.code === '404'
+    response.body  === {
+      code: '404',
+      error: 'not_found',
+      message: expected_message
+    }.to_json
+  end
+end


### PR DESCRIPTION
@mixonic a helper function to return 404 errors from the API and also an RSpec matcher. CC @bantic 
