### PR TITLE
Add routes for deleting image set

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -24,11 +24,11 @@ class ApiController < ApplicationController
            }
   end
 
-  def deny_access
+  def deny_access(message='User must be signed in')
     render status: 401, json: {
       code: '401',
       error: 'unathenticated',
-      message: 'User must be signed in'
+      message: message
     }
   end
 
@@ -53,6 +53,11 @@ class ApiController < ApplicationController
     @image_set = ImageSet.find_by_id(params[:id]) ||
                  ImageSet.find_by_id(params[:image_set_id])
     return error_not_found('image set not found') unless @image_set
+  end
+
+  def require_image_set_ownership
+    user_owns_image_set = @image_set.organization == current_user.organization
+    return deny_access('user cannot delete image set') unless user_owns_image_set
   end
 
   def require_organization

--- a/app/controllers/image_sets_controller.rb
+++ b/app/controllers/image_sets_controller.rb
@@ -1,5 +1,6 @@
 class ImageSetsController < ApiController
   before_filter :require_image_set, except: [:create, :index]
+  before_filter :require_image_set_ownership, only: [:destroy, :update]
   before_filter :require_organization, only: [:index]
   before_filter :require_current_user_in_organization, only: [:index]
 
@@ -25,6 +26,12 @@ class ImageSetsController < ApiController
     render_image_set
   end
 
+  def destroy
+    @image_set.destroy
+
+    render json: {}, status: 204
+  end
+
   private
 
   def render_image_set
@@ -45,6 +52,7 @@ class ImageSetsController < ApiController
   def image_set_params
     params.require(:image_set).
       permit(
+          :id,
           :url,
           :lion,
           :user_id,

--- a/config/application.rb
+++ b/config/application.rb
@@ -37,7 +37,7 @@ module LionGuardiansApi
       allow do
         origins '*'
         cors_params = { headers: %w(Accept Authorization Content-Type),
-                        methods: [:options, :patch, :get, :post, :put],
+                        methods: [:options, :patch, :get, :post, :delete, :put],
                         credentials: true }
 
         %w(/*).each do |resource_path|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
 
   resources :cv_requests, only:[:create, :show], path: 'cvRequests'
   resources :cv_results, only:[:index], path: 'cvResults'
-  resources :image_sets, only:[:create, :show, :update, :index], path: 'imageSets'
+  resources :image_sets, only:[:create, :show, :update, :destroy, :index], path: 'imageSets'
   resources :images, only:[:create, :show, :update]
   resources :lions, only:[:show, :index]
   resources :organizations, only: [:index]

--- a/spec/controllers/image_sets_controller_spec.rb
+++ b/spec/controllers/image_sets_controller_spec.rb
@@ -73,7 +73,8 @@ RSpec.describe ImageSetsController, :type => :controller do
   end
 
   describe '#update' do
-    let(:image_set) { Fabricate :image_set_with_images, main_image: nil }
+    let(:user) { resource }
+    let(:image_set) { Fabricate :image_set_with_images, main_image: nil, organization: user.organization }
     let(:main_image) { image_set.images.first }
     let(:request) { -> { put :update, id: image_set.id, image_set: params } }
     let(:params) {
@@ -87,5 +88,38 @@ RSpec.describe ImageSetsController, :type => :controller do
       expect { subject }.to \
         change { image_set.reload.main_image }.from(nil).to(main_image)
     }
+
+    describe 'not found' do
+      let(:request) { ->{ put :update, id: 'bad id' } }
+      it { expect(subject).to error_not_found_with('image set not found') }
+    end
+
+    describe 'user does not own image set' do
+      let(:user) { Fabricate :user }
+      it { expect(subject).to error_deny_access }
+    end
+  end
+
+  describe '#destroy' do
+    let(:user) { resource }
+    let!(:image_set) { Fabricate :image_set_with_images, organization: user.organization }
+    let(:request) { -> { delete :destroy, id: image_set.id } }
+
+    it_behaves_like "an authenticated controller"
+    it { expect { subject }.to change { ImageSet.count }.by(-1) }
+
+    #eventually this should delete images as well, in a delayed queue most likely
+    xit { expect { subject }.to change { Image.count }.by(5) }
+
+    describe 'not found' do
+      let(:request) { ->{ delete :destroy, id: 'bad id' } }
+      it { expect(subject).to error_not_found_with('image set not found') }
+    end
+
+    describe 'user does not own image set' do
+      let!(:image_set) { Fabricate :image_set }
+      let(:request) { ->{ delete :destroy, id: image_set.id } }
+      it { expect(subject).to error_deny_access }
+    end
   end
 end

--- a/spec/support/errors.rb
+++ b/spec/support/errors.rb
@@ -6,12 +6,29 @@ RSpec::Matchers.define :error_not_found do
   end
 end
 
+RSpec::Matchers.define :error_deny_access do
+  match do |actual|
+    response.code === '401'
+  end
+end
+
 RSpec::Matchers.define :error_not_found_with do |expected_message|
   match do |actual|
     response.code === '404'
     response.body  === {
       code: '404',
       error: 'not_found',
+      message: expected_message
+    }.to_json
+  end
+end
+
+RSpec::Matchers.define :error_deny_access_with do |expected_message|
+  match do |actual|
+    response.code === '401'
+    response.body  === {
+      code: '401',
+      error: 'unauthenticated',
       message: expected_message
     }.to_json
   end


### PR DESCRIPTION
@iezer This is missing tests, but wanted to get you an update tonight as the functionality is working. I'll follow up with some tests to confirm the behavior in the morning.

This receives delete request from the front-end and removes an image_set. I'll test to confirm images within the image_set are deleted as well. 
