### PR TITLE
Change age to datetime on lions, but get and set as integer age

### DIFF
--- a/app/controllers/lions_controller.rb
+++ b/app/controllers/lions_controller.rb
@@ -6,7 +6,7 @@ class LionsController < ApiController
   end
 
   def index
-    @lions = Lion.where(search_params)
+    @lions = Lion.search(search_params)
 
     render json: LionsSerializer.new(@lions)
   end

--- a/app/models/image_set.rb
+++ b/app/models/image_set.rb
@@ -20,6 +20,10 @@ class ImageSet < ActiveRecord::Base
 
   validate :main_image_in_image_set
 
+  def age=(val)
+    @age = val.to_i
+  end
+
   private
 
   def main_image_in_image_set

--- a/app/models/lion.rb
+++ b/app/models/lion.rb
@@ -23,6 +23,34 @@ class Lion < ActiveRecord::Base
     lion
   end
 
+  def self.search(search_params)
+    if search_params[:age]
+      age_int = search_params[:age].to_i
+      search_params[:age] = convert_age_to_birthdate(age_int)
+    end
+
+    Lion.where(search_params)
+  end
+
+  def self.convert_age_to_birthdate(age)
+    Date.today - age.years
+  end
+
+  def birthdate
+    self[:age]
+  end
+
+  def age=(val)
+    self[:age] = val ? self.class.convert_age_to_birthdate(val.to_i) : val # leave age as nil if not provided
+  end
+
+  def age
+    return nil unless self[:age]
+
+    difference = (Date.today - self[:age].to_date)/365.to_f.to_i
+    difference.to_i
+  end
+
   private
 
   def primary_image_set_in_image_sets

--- a/db/migrate/20150212132420_convert_age_to_datetime.rb
+++ b/db/migrate/20150212132420_convert_age_to_datetime.rb
@@ -1,0 +1,6 @@
+class ConvertAgeToDatetime < ActiveRecord::Migration
+  def change
+    remove_column :lions, :age
+    add_column :lions, :age, :datetime
+  end
+end

--- a/db/migrate/20150212134953_change_image_set_age_from_string_to_integer.rb
+++ b/db/migrate/20150212134953_change_image_set_age_from_string_to_integer.rb
@@ -1,0 +1,6 @@
+class ChangeImageSetAgeFromStringToInteger < ActiveRecord::Migration
+  def change
+    remove_column :image_sets, :age
+    add_column :image_sets, :age, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150206195604) do
+ActiveRecord::Schema.define(version: 20150212134953) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -83,10 +83,10 @@ ActiveRecord::Schema.define(version: 20150206195604) do
     t.decimal  "longitude",                 precision: 10, scale: 6
     t.datetime "photo_date"
     t.string   "gender"
-    t.string   "age"
     t.boolean  "is_primary",                                         default: false
     t.datetime "created_at",                                                         null: false
     t.datetime "updated_at",                                                         null: false
+    t.integer  "age"
   end
 
   create_table "images", force: :cascade do |t|
@@ -102,10 +102,10 @@ ActiveRecord::Schema.define(version: 20150206195604) do
     t.string   "name",                 null: false
     t.integer  "organization_id"
     t.string   "gender"
-    t.string   "age"
     t.datetime "created_at",           null: false
     t.datetime "updated_at",           null: false
     t.integer  "primary_image_set_id"
+    t.datetime "age"
   end
 
   add_index "lions", ["name"], name: "index_lions_on_name", unique: true, using: :btree

--- a/spec/controllers/lions_controller_spec.rb
+++ b/spec/controllers/lions_controller_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe LionsController, :type => :controller do
   end
 
   describe '#index' do
-    let(:lion1) { Fabricate(:lion, age: '24', gender:'male')}
-    let(:lion2) { Fabricate(:lion, age: '25', gender:'female')}
+    let(:lion1) { Fabricate(:lion, age: 24, gender:'male')}
+    let(:lion2) { Fabricate(:lion, age: 25, gender:'female')}
     let!(:lions) { [lion1, lion2] }
     let(:request) { ->{ get :index, params } }
 

--- a/spec/models/lion_spec.rb
+++ b/spec/models/lion_spec.rb
@@ -23,4 +23,13 @@ RSpec.describe Lion, :type => :model do
     it { expect(lion.organization).to eq image_set.organization }
     it { expect(image_set.reload.lion).to eq lion }
   end
+
+  describe 'set age' do
+    let(:birthdate) { Date.today - 26.years }
+    let(:lion) { Fabricate :lion, age: 26 }
+
+    it { expect(lion).to be_valid }
+    it { expect(lion.age).to eq 26 }
+    it { expect(lion.birthdate).to eq birthdate }
+  end
 end


### PR DESCRIPTION
@iezer This one isn't quite ready to merge yet, as it creates problems with the lion serializer that I haven't yet nailed down. There's also something very odd happening with the db/schema, where the column types are not matching up to what's specified in the migrations. I'm not sure if it's a problem, especially if the local schema is consistent with the migrations, but it's quite odd. 

Could you take a look at the serializer rspec errors to see if there's anything you can make out of them? Is there some other place properties are specified that I perhaps need to tweak? 

Thanks for any help! 
