### PR TITLE
API updates

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -32,11 +32,10 @@ class ApiController < ApplicationController
     }
   end
 
-  def error_invalid_resource(message='invalid resource')
+  def error_invalid_resource(errors={})
     render status: 422, json: {
              code: '422',
-             error: 'invalid_resource',
-             message: message
+             errors: errors
            }
   end
 

--- a/app/controllers/cv_results_controller.rb
+++ b/app/controllers/cv_results_controller.rb
@@ -2,7 +2,7 @@ class CvResultsController < ApiController
   before_filter :require_image_set
 
   def index
-    @cv_results = @image_set.cv_results
+    @cv_results = @image_set.cv_results.by_probability
     render json: CvResultsSerializer.new(@cv_results, current_user: current_user)
   end
 end

--- a/app/controllers/cv_results_controller.rb
+++ b/app/controllers/cv_results_controller.rb
@@ -3,6 +3,6 @@ class CvResultsController < ApiController
 
   def index
     @cv_results = @image_set.cv_results
-    render json: CvResultsSerializer.new(@cv_results)
+    render json: CvResultsSerializer.new(@cv_results, current_user: current_user)
   end
 end

--- a/app/controllers/lions_controller.rb
+++ b/app/controllers/lions_controller.rb
@@ -2,27 +2,42 @@ class LionsController < ApiController
   def show
     @lion = Lion.find(params[:id])
 
-    render json: LionSerializer.new(@lion)
+    render_lion
   end
 
   def index
     @lions = Lion.where(search_params)
 
-    render json: LionsSerializer.new(@lions)
+    render_lions
   end
 
   def create
     @image_set = ImageSet.find_by_id(creation_params[:primary_image_set_id])
-    return error_not_found('image_set for lion creation not found') unless @image_set
-    return error_invalid_resource('image_set already associated with lion') if @image_set.lion.present?
+    return error_invalid_resource(primary_image_set: ['for lion creation not found']) unless @image_set
+    if @image_set.lion.present?
+      return error_invalid_resource(primary_image_set: ['already associated with another lion'])
+    end
+
 
     @name = creation_params[:name]
     @lion = Lion.create_from_image_set(@image_set, @name)
 
-    render json: LionSerializer.new(@lion)
+    render_lion
   end
 
   private
+
+  def render_lion
+    if @lion.valid?
+      render json: LionSerializer.new(@lion, current_user: current_user)
+    else
+      error_invalid_resource(@lion.errors)
+    end
+  end
+
+  def render_lions
+    render json: LionsSerializer.new(@lions, current_user: current_user)
+  end
 
   def creation_params
     params.require(:lion).permit(

--- a/app/models/cv_result.rb
+++ b/app/models/cv_result.rb
@@ -8,4 +8,6 @@ class CvResult < ActiveRecord::Base
 
   has_one :image_set, through: :image
   has_one :lion, through: :image_set
+
+  scope :by_probability, ->{ order('match_probability DESC') }
 end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -6,6 +6,8 @@ class Image < ActiveRecord::Base
     :inclusion  => { :in => [ 'cv', 'full-body', 'whisker', 'main-id', 'markings' ],
     :message    => "%{value} is not a valid image type" }
 
+  scope :is_public, ->{ where(is_public: true) }
+
   def hide
     update(is_deleted: true)
   end

--- a/app/serializers/cv_result_serializer.rb
+++ b/app/serializers/cv_result_serializer.rb
@@ -6,6 +6,9 @@ class CvResultSerializer < BaseSerializer
 
     if item.lion
       entity :lion, item.lion, LionSerializer
+
+      # Lion serializer will serialize all image sets
+      # so just include image_set_id here.
       property :image_set_id, item.image_set.id
     else
       entity :image_set, item.image_set, ImageSetSerializer, embedded: true

--- a/app/serializers/image_set_serializer.rb
+++ b/app/serializers/image_set_serializer.rb
@@ -10,7 +10,8 @@ class ImageSetSerializer < BaseSerializer
     property :has_cv_results, !item.cv_results.empty?
     property :cv_request_id, item.cv_request.id if item.cv_request
 
-    entities :images, item.images, ImageSerializer
+    entities :images, item.viewable_images(context[:current_user]), ImageSerializer
+
     entity :uploading_organization, item.uploading_organization, OrganizationSerializer
 
     # Avoid infinite circular embeds

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -14,9 +14,9 @@ image_set_1 = ImageSet.create(
     latitude: -2.6527,
     longitude: 37.26058,
     images_attributes: [
-      {url: lion_img_url_1, image_type: 'cv'},
-      {url: lion_img_url_2, image_type: 'whisker'},
-      {url: lion_img_url_3, image_type: 'markings'}
+      {url: lion_img_url_1, is_public: true, image_type: 'cv'},
+      {url: lion_img_url_2, is_public: true, image_type: 'whisker'},
+      {url: lion_img_url_3, is_public: true, image_type: 'markings'}
     ]
   }
 )
@@ -40,9 +40,9 @@ image_set_2 = ImageSet.create(
     latitude: -2.6527,
     longitude: 37.26058,
     images_attributes: [
-      {url: lion_img_url_1, image_type: 'cv'},
-      {url: lion_img_url_2, image_type: 'whisker'},
-      {url: lion_img_url_3, image_type: 'markings'}
+      {url: lion_img_url_1, is_public: true, image_type: 'cv'},
+      {url: lion_img_url_2, is_public: true, image_type: 'whisker'},
+      {url: lion_img_url_3, is_public: true, image_type: 'markings'}
     ]
   }
 )
@@ -63,9 +63,9 @@ image_set_3 = ImageSet.create(
     latitude: -2.6527,
     longitude: 37.26058,
     images_attributes: [
-      {url: lion_img_url_1, image_type: 'cv'},
-      {url: lion_img_url_2, image_type: 'whisker'},
-      {url: lion_img_url_3, image_type: 'markings'}
+      {url: lion_img_url_1, is_public: true, image_type: 'cv'},
+      {url: lion_img_url_2, is_public: true, image_type: 'whisker'},
+      {url: lion_img_url_3, is_public: true, image_type: 'markings'}
     ]
   }
 )
@@ -82,9 +82,9 @@ image_set_cv = ImageSet.create(
     latitude: -2.6527,
     longitude: 37.26058,
     images_attributes: [
-      {url: lion_img_url_1, image_type: 'cv'},
-      {url: lion_img_url_2, image_type: 'whisker'},
-      {url: lion_img_url_3, image_type: 'markings'}
+      {url: lion_img_url_1, is_public: true, image_type: 'cv'},
+      {url: lion_img_url_2, is_public: true, image_type: 'whisker'},
+      {url: lion_img_url_3, is_public: true, image_type: 'markings'}
     ]
   }
 )

--- a/spec/controllers/lions_controller_spec.rb
+++ b/spec/controllers/lions_controller_spec.rb
@@ -54,5 +54,31 @@ RSpec.describe LionsController, :type => :controller do
     it_behaves_like "an authenticated controller"
     it { expect { subject }.to change { Lion.count }.by(1) }
     it { expect(subject).to serialize_to(LionSerializer, Lion.all.last) }
+
+    describe 'bad image set id' do
+      let(:params) { { lion: {name: 'isaac'} } }
+      it {
+        expect(subject).to error_invalid_resource_with(
+                             { primary_image_set: ["for lion creation not found"] })
+      }
+    end
+
+    describe 'bad image set' do
+      before { image_set.update(lion: Fabricate(:lion)) }
+
+      it {
+        expect(subject).to error_invalid_resource_with(
+                             { primary_image_set: ["already associated with another lion"] })
+      }
+    end
+
+    describe 'missing name' do
+      let(:params) { { lion: {primary_image_set_id: image_set.id} } }
+      it {
+        expect(subject).to error_invalid_resource_with(
+                             { name: ["can't be blank"] })
+      }
+    end
+
   end
 end

--- a/spec/fabricators/image_set_fabricator.rb
+++ b/spec/fabricators/image_set_fabricator.rb
@@ -8,10 +8,18 @@ end
 
 Fabricator(:image_set_with_images, from: :image_set) do
   images(count: 5)
-  main_image { |attrs| attrs[:images].first }
+  main_image {
+    |attrs| attrs[:images].first.tap{
+      |image| image.update(is_public: true)
+    }
+  }
 end
 
 Fabricator(:image_set_with_1_image, from: :image_set) do
   images(count: 1)
-  main_image { |attrs| attrs[:images].first }
+  main_image {
+    |attrs| attrs[:images].first.tap {
+      |image| image.update(is_public: true)
+    }
+  }
 end

--- a/spec/support/errors.rb
+++ b/spec/support/errors.rb
@@ -33,3 +33,23 @@ RSpec::Matchers.define :error_deny_access_with do |expected_message|
     }.to_json
   end
 end
+
+RSpec::Matchers.define :error_invalid_resource_with do |expected_errors|
+  match do |actual|
+    response.code === '422'
+    response.body  === {
+      code: '422',
+      errors: expected_errors
+    }.to_json
+  end
+
+  failure_message_for_should do |response|
+    normalised_response = {
+      code: '422',
+      errors: expected_errors
+    }.to_json
+    decoded = response.body
+
+    "expected api to have exposed 422, #{normalised_response.inspect}, got #{response.code} #{decoded.inspect} instead."
+  end
+end

--- a/spec/support/serialize_to.rb
+++ b/spec/support/serialize_to.rb
@@ -6,4 +6,8 @@ RSpec::Matchers.define :serialize_to do |expected_serializer, expected_value|
   match do |actual|
     actual.body === expected
   end
+
+  failure_message_for_should do |response|
+    "expected api to return #{expected.inspect} but got #{actual.body.inspect} instead"
+  end
 end


### PR DESCRIPTION
@bantic  For you, CC @redyaffle 
- Present public images only to users who do not own an image set. Do this by having an is_public scope on images and passing the current_user into the serializer.
  - return server errors in a format that can be displayed on the front end. Adds some test helpers for this.
- Some basic validations like image_sets cannot be moved from 1 lion to another and IDs have to be valid.
- make sure the main image on an image set is public.
