### PR TITLE
Update lion search to use image_sets.search for tags

### DIFF
--- a/app/controllers/image_sets_controller.rb
+++ b/app/controllers/image_sets_controller.rb
@@ -52,7 +52,11 @@ class ImageSetsController < ApiController
   end
 
   def search_params
-    _params = params.permit(:age, :gender, :name, :organization_id, tags: [])
+    _params = params.permit(:dob_range_start, :dob_range_end, #age
+                            :gender,
+                            :name,
+                            :organization_id,
+                            tags: [])
 
     if _params[:organization_id]
       _params[:owner_organization_id] = _params.delete(:organization_id)

--- a/app/controllers/lions_controller.rb
+++ b/app/controllers/lions_controller.rb
@@ -72,6 +72,10 @@ class LionsController < ApiController
   end
 
   def search_params
-    params.permit(:dob_range_start, :dob_range_end, :gender, :organization_id, :name)
+     params.permit(:dob_range_start, :dob_range_end, #age
+                    :gender,
+                    :name,
+                    :organization_id,
+                    tags: [])
   end
 end

--- a/app/models/image_set.rb
+++ b/app/models/image_set.rb
@@ -31,7 +31,6 @@ class ImageSet < ActiveRecord::Base
 
   before_destroy :hide_images
 
-
   scope :for_tags, ->(tags) {
     unless tags && tags.empty?
       where("tags @> ARRAY[?]::varchar[]", tags)

--- a/app/models/image_set.rb
+++ b/app/models/image_set.rb
@@ -20,6 +20,18 @@ class ImageSet < ActiveRecord::Base
 
   validate :valid_tags
 
+  accepts_nested_attributes_for :images
+
+  validates_associated :images
+  validate :main_image_in_image_set
+  validate :main_image_is_public
+
+  # make sure lion_id is nil or pointing to a real lion
+  validates :lion, presence: true, if: "lion_id.present?"
+
+  before_destroy :hide_images
+
+
   scope :for_tags, ->(tags) {
     unless tags && tags.empty?
       where("tags @> ARRAY[?]::varchar[]", tags)
@@ -29,14 +41,21 @@ class ImageSet < ActiveRecord::Base
   }
 
   def self.search(params)
-    tags = params.delete(:tags)
+    age_params = params.extract!(:dob_range_start, :dob_range_end)
 
+    unless age_params.empty?
+      dob_start = DateTime.parse(age_params[:dob_range_start])
+      dob_end = DateTime.parse(age_params[:dob_range_end])
+      dob_hash = { date_of_birth: (dob_start..dob_end) }
+      params.merge!(dob_hash)
+    end
+
+    tags = params.delete(:tags)
     query = ImageSet.where(params).order('created_at desc')
 
     if params.has_key?(:lions)
       query = query.joins(:lion)
     end
-
 
     if tags && !tags.empty?
       query = query.for_tags(tags)
@@ -54,17 +73,6 @@ class ImageSet < ActiveRecord::Base
       end
     end
   end
-
-  accepts_nested_attributes_for :images
-
-  validates_associated :images
-  validate :main_image_in_image_set
-  validate :main_image_is_public
-
-  # make sure lion_id is nil or pointing to a real lion
-  validates :lion, presence: true, if: "lion_id.present?"
-
-  before_destroy :hide_images
 
   def viewable_images(user)
     if owner? user

--- a/spec/models/image_set_spec.rb
+++ b/spec/models/image_set_spec.rb
@@ -79,6 +79,41 @@ RSpec.describe ImageSet, :type => :model do
     end
   end
 
+  describe '#search' do
+    subject { ImageSet.search(search_params) }
+    let(:search_params) { {} }
+
+    context 'for tags' do
+      let(:tag_1) { LG::ImageSetMetaData::OPTIONS[0] }
+      let(:tag_2) { LG::ImageSetMetaData::OPTIONS[1] }
+
+      let!(:no_tag_image_set) { Fabricate :image_set, tags: [] }
+      let!(:tag_1_image_set) { Fabricate :image_set, tags: [tag_1] }
+      let!(:tag_1_and_2_image_set) { Fabricate :image_set, tags: [tag_1, tag_2] }
+
+      context 'no tags' do
+        let(:search_params) { {tags:[]} }
+        it { expect(subject).to include(tag_1_image_set) }
+        it { expect(subject).to include(tag_1_and_2_image_set) }
+        it { expect(subject).to include(no_tag_image_set) }
+      end
+
+      context '1 tag' do
+        let(:search_params) { {tags:[tag_1]} }
+        it { expect(subject).to include(tag_1_image_set) }
+        it { expect(subject).to include(tag_1_and_2_image_set) }
+        it { expect(subject).not_to include(no_tag_image_set) }
+      end
+
+      context '2 tags finds sets with all tags' do
+        let(:search_params) { {tags:[tag_1, tag_2]} }
+        it { expect(subject).not_to include(tag_1_image_set) }
+        it { expect(subject).not_to include(no_tag_image_set) }
+        it { expect(subject).to include(tag_1_and_2_image_set) }
+      end
+    end
+  end
+
   describe 'fetching cv_results for image_set' do
     let(:cv_request) { Fabricate :cv_request }
     let(:image_set) { cv_request.image_set }

--- a/spec/models/lion_spec.rb
+++ b/spec/models/lion_spec.rb
@@ -32,9 +32,7 @@ RSpec.describe Lion, :type => :model do
 
       let(:params) { {name: name} }
 
-      it {
-        expect(subject).to eq([lion1])
-      }
+      it { expect(subject).to eq([lion1]) }
     end
 
     context 'by gender' do
@@ -43,9 +41,53 @@ RSpec.describe Lion, :type => :model do
 
       let(:params) { {gender: 'female'} }
 
-      it {
-        expect(subject).to eq([female_lion])
+      it { expect(subject).to eq([female_lion]) }
+    end
+
+    context 'by tag' do
+      let(:tag_1) { LG::ImageSetMetaData::OPTIONS[0] }
+      let(:tag_2) { LG::ImageSetMetaData::OPTIONS[1] }
+
+      let(:image_set_no_tags) { Fabricate(:image_set, tags:[]) }
+      let(:image_set_tag_1) { Fabricate(:image_set, tags:[tag_1]) }
+      let(:image_set_tag_1_and_2) { Fabricate(:image_set, tags:[tag_1, tag_2]) }
+
+      let!(:lion_no_tags) {
+        Fabricate(:lion,
+                  image_sets:[image_set_no_tags],
+                  primary_image_set:image_set_no_tags)
       }
+      let!(:lion_1_tag) {
+        Fabricate(:lion,
+                  image_sets:[image_set_tag_1],
+                  primary_image_set:image_set_tag_1)
+      }
+      let!(:lion_2_tags) {
+        Fabricate(:lion,
+                  image_sets:[image_set_tag_1_and_2],
+                  primary_image_set:image_set_tag_1_and_2)
+      }
+
+      context 'no tags' do
+        let(:params) { {tags: []} }
+        it { expect(subject).to include(lion_no_tags) }
+        it { expect(subject).to include(lion_1_tag) }
+        it { expect(subject).to include(lion_2_tags) }
+      end
+
+      context '1 tag' do
+        let(:params) { {tags: [tag_1]} }
+        it { expect(subject).not_to include(lion_no_tags) }
+        it { expect(subject).to include(lion_1_tag) }
+        it { expect(subject).to include(lion_2_tags) }
+      end
+
+      context '2 tags includes image sets with BOTH tags' do
+        let(:params) { {tags: [tag_1, tag_2]} }
+        it { expect(subject).not_to include(lion_no_tags) }
+        it { expect(subject).not_to include(lion_1_tag) }
+        it { expect(subject).to include(lion_2_tags) }
+      end
     end
   end
 end


### PR DESCRIPTION
@bantic for your review!

I adjusted the model to move scopes and validations to the top so they can all be seen at once. I expanded ImageSet.search to be able to search by age and Lion.search to search by tags (metadata). I chose to split the query for lion search into two - the first to query image sets and the second to query lions for the results of image sets. This avoided some duplication of scope and param manipulation, but expands the query count unnecessarily. I didn't want to play around with it too much further once I got it working in the interests of time, but if you think there's a more effective way, please comment below! 

Thanks!
